### PR TITLE
feat(service, test): implement TokensService, add integration tests

### DIFF
--- a/drizzle/0001_authorization_tables.sql
+++ b/drizzle/0001_authorization_tables.sql
@@ -1,0 +1,59 @@
+CREATE TABLE "roles" (
+  "role_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" varchar(50) NOT NULL UNIQUE,
+  "description" text,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "permissions" (
+  "permission_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" varchar(100) NOT NULL UNIQUE,
+  "description" text,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user_roles" (
+  "user_id" uuid NOT NULL,
+  "role_id" uuid NOT NULL,
+  "assigned_at" timestamp DEFAULT now() NOT NULL,
+  "assigned_by" uuid,
+  "expires_at" timestamp,
+  PRIMARY KEY ("user_id", "role_id")
+);
+--> statement-breakpoint
+CREATE TABLE "role_permissions" (
+  "role_id" uuid NOT NULL,
+  "permission_id" uuid NOT NULL,
+  "assigned_at" timestamp DEFAULT now() NOT NULL,
+  "assigned_by" uuid,
+  PRIMARY KEY ("role_id", "permission_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_permissions" (
+  "user_id" uuid NOT NULL,
+  "permission_id" uuid NOT NULL,
+  "assigned_at" timestamp DEFAULT now() NOT NULL,
+  "assigned_by" uuid,
+  "expires_at" timestamp,
+  PRIMARY KEY ("user_id", "permission_id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_role_id_roles_role_id_fk" FOREIGN KEY ("role_id") REFERENCES "roles"("role_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_assigned_by_users_user_id_fk" FOREIGN KEY ("assigned_by") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_role_id_roles_role_id_fk" FOREIGN KEY ("role_id") REFERENCES "roles"("role_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_permission_id_permissions_permission_id_fk" FOREIGN KEY ("permission_id") REFERENCES "permissions"("permission_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_assigned_by_users_user_id_fk" FOREIGN KEY ("assigned_by") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_permission_id_permissions_permission_id_fk" FOREIGN KEY ("permission_id") REFERENCES "permissions"("permission_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_assigned_by_users_user_id_fk" FOREIGN KEY ("assigned_by") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/0002_seed_roles_permissions.sql
+++ b/drizzle/0002_seed_roles_permissions.sql
@@ -1,0 +1,69 @@
+-- Insert default roles
+INSERT INTO "roles" ("name", "description") VALUES
+('admin', 'Administrator with full access to all features'),
+('issuer', 'Can create and manage badges and issue them to recipients'),
+('recipient', 'Can receive and manage their own badges'),
+('verifier', 'Can verify badges but not issue them'),
+('guest', 'Limited access to public features only');
+
+-- Insert default permissions
+INSERT INTO "permissions" ("name", "description") VALUES
+('read:credentials', 'Read credential data'),
+('create:credentials', 'Create new credentials'),
+('update:credentials', 'Update existing credentials'),
+('delete:credentials', 'Delete credentials'),
+('verify:credentials', 'Verify credential authenticity'),
+('read:profile', 'Read user profile data'),
+('update:profile', 'Update user profile data'),
+('read:users', 'Read user data'),
+('create:users', 'Create new users'),
+('update:users', 'Update existing users'),
+('delete:users', 'Delete users'),
+('read:issuers', 'Read issuer data'),
+('create:issuers', 'Create new issuers'),
+('update:issuers', 'Update existing issuers'),
+('delete:issuers', 'Delete issuers');
+
+-- Assign permissions to roles
+-- Admin role gets all permissions
+INSERT INTO "role_permissions" ("role_id", "permission_id")
+SELECT r.role_id, p.permission_id
+FROM "roles" r, "permissions" p
+WHERE r.name = 'admin';
+
+-- Issuer role permissions
+INSERT INTO "role_permissions" ("role_id", "permission_id")
+SELECT r.role_id, p.permission_id
+FROM "roles" r, "permissions" p
+WHERE r.name = 'issuer' AND p.name IN (
+  'read:credentials', 'create:credentials', 'update:credentials',
+  'read:profile', 'update:profile',
+  'read:issuers', 'update:issuers'
+);
+
+-- Recipient role permissions
+INSERT INTO "role_permissions" ("role_id", "permission_id")
+SELECT r.role_id, p.permission_id
+FROM "roles" r, "permissions" p
+WHERE r.name = 'recipient' AND p.name IN (
+  'read:credentials', 'verify:credentials',
+  'read:profile', 'update:profile'
+);
+
+-- Verifier role permissions
+INSERT INTO "role_permissions" ("role_id", "permission_id")
+SELECT r.role_id, p.permission_id
+FROM "roles" r, "permissions" p
+WHERE r.name = 'verifier' AND p.name IN (
+  'read:credentials', 'verify:credentials',
+  'read:profile'
+);
+
+-- Guest role permissions
+INSERT INTO "role_permissions" ("role_id", "permission_id")
+SELECT r.role_id, p.permission_id
+FROM "roles" r, "permissions" p
+WHERE r.name = 'guest' AND p.name IN (
+  'verify:credentials',
+  'read:profile'
+);

--- a/drizzle/0003_authorization_fk.sql
+++ b/drizzle/0003_authorization_fk.sql
@@ -1,0 +1,12 @@
+-- Add foreign key constraints for authorization tables
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_role_id_roles_role_id_fk" FOREIGN KEY ("role_id") REFERENCES "roles"("role_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_assigned_by_users_user_id_fk" FOREIGN KEY ("assigned_by") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+
+ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_role_id_roles_role_id_fk" FOREIGN KEY ("role_id") REFERENCES "roles"("role_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_permission_id_permissions_permission_id_fk" FOREIGN KEY ("permission_id") REFERENCES "permissions"("permission_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_assigned_by_users_user_id_fk" FOREIGN KEY ("assigned_by") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_permission_id_permissions_permission_id_fk" FOREIGN KEY ("permission_id") REFERENCES "permissions"("permission_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_assigned_by_users_user_id_fk" FOREIGN KEY ("assigned_by") REFERENCES "users"("user_id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/0004_keys_table.sql
+++ b/drizzle/0004_keys_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "keys" (
+  "key_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "issuer_id" uuid NOT NULL,
+  "type" varchar(50) NOT NULL,
+  "algorithm" varchar(50) NOT NULL,
+  "public_key" text NOT NULL,
+  "private_key" text,
+  "status" varchar(20) NOT NULL DEFAULT 'active',
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  "expires_at" timestamp,
+  "revoked_at" timestamp,
+  "revocation_reason" text
+);
+
+ALTER TABLE "keys" ADD CONSTRAINT "keys_issuer_id_issuer_profiles_issuer_id_fk" FOREIGN KEY ("issuer_id") REFERENCES "issuer_profiles"("issuer_id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/drizzle/0005_keys_schema_fix.sql
+++ b/drizzle/0005_keys_schema_fix.sql
@@ -1,0 +1,20 @@
+-- Drop the existing keys table
+DROP TABLE IF EXISTS "keys";
+
+-- Create the keys table with the correct schema
+CREATE TABLE "keys" (
+  "id" text PRIMARY KEY NOT NULL,
+  "type" text NOT NULL,
+  "algorithm" text NOT NULL,
+  "public_key" text NOT NULL,
+  "private_key" text,
+  "name" text,
+  "description" text,
+  "version" text,
+  "previous_key_id" text,
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "expires_at" timestamp,
+  "revoked_at" timestamp,
+  "revocation_reason" text,
+  "is_active" boolean NOT NULL DEFAULT true
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,371 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "id": "c9a9e9e9-9e9e-9e9e-9e9e-9e9e9e9e9e9e",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_user_id_fk": {
+          "name": "user_roles_user_id_users_user_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_role_id_fk": {
+          "name": "user_roles_role_id_roles_role_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_roles_assigned_by_users_user_id_fk": {
+          "name": "user_roles_assigned_by_users_user_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_role_id_fk": {
+          "name": "role_permissions_role_id_roles_role_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_permission_id_fk": {
+          "name": "role_permissions_permission_id_permissions_permission_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "permission_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_permissions_assigned_by_users_user_id_fk": {
+          "name": "role_permissions_assigned_by_users_user_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "user_permissions": {
+      "name": "user_permissions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_permissions_user_id_users_user_id_fk": {
+          "name": "user_permissions_user_id_users_user_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_permissions_permission_id_permissions_permission_id_fk": {
+          "name": "user_permissions_permission_id_permissions_permission_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "permission_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_permissions_assigned_by_users_user_id_fk": {
+          "name": "user_permissions_assigned_by_users_user_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_permissions_user_id_permission_id_pk": {
+          "name": "user_permissions_user_id_permission_id_pk",
+          "columns": [
+            "user_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {}
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,371 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "id": "d9a9e9e9-9e9e-9e9e-9e9e-9e9e9e9e9e9e",
+  "prevId": "c9a9e9e9-9e9e-9e9e-9e9e-9e9e9e9e9e9e",
+  "tables": {
+    "roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_user_id_fk": {
+          "name": "user_roles_user_id_users_user_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_role_id_fk": {
+          "name": "user_roles_role_id_roles_role_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_roles_assigned_by_users_user_id_fk": {
+          "name": "user_roles_assigned_by_users_user_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": [
+            "user_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_role_id_fk": {
+          "name": "role_permissions_role_id_roles_role_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_permission_id_fk": {
+          "name": "role_permissions_permission_id_permissions_permission_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "permission_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_permissions_assigned_by_users_user_id_fk": {
+          "name": "role_permissions_assigned_by_users_user_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "name": "role_permissions_role_id_permission_id_pk",
+          "columns": [
+            "role_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "user_permissions": {
+      "name": "user_permissions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_permissions_user_id_users_user_id_fk": {
+          "name": "user_permissions_user_id_users_user_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_permissions_permission_id_permissions_permission_id_fk": {
+          "name": "user_permissions_permission_id_permissions_permission_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "permission_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_permissions_assigned_by_users_user_id_fk": {
+          "name": "user_permissions_assigned_by_users_user_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_permissions_user_id_permission_id_pk": {
+          "name": "user_permissions_user_id_permission_id_pk",
+          "columns": [
+            "user_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {}
+}

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,110 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "id": "e9a9e9e9-9e9e-9e9e-9e9e-9e9e9e9e9e9e",
+  "prevId": "d9a9e9e9-9e9e-9e9e-9e9e-9e9e9e9e9e9e",
+  "tables": {
+    "keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issuer_id": {
+          "name": "issuer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keys_issuer_id_issuer_profiles_issuer_id_fk": {
+          "name": "keys_issuer_id_issuer_profiles_issuer_id_fk",
+          "tableFrom": "keys",
+          "tableTo": "issuer_profiles",
+          "columnsFrom": [
+            "issuer_id"
+          ],
+          "columnsTo": [
+            "issuer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {}
+}

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,106 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "id": "f9a9e9e9-9e9e-9e9e-9e9e-9e9e9e9e9e9e",
+  "prevId": "e9a9e9e9-9e9e-9e9e-9e9e-9e9e9e9e9e9e",
+  "tables": {
+    "keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_key_id": {
+          "name": "previous_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revocation_reason": {
+          "name": "revocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,34 @@
       "when": 1743970780857,
       "tag": "0000_fluffy_unicorn",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1743970780858,
+      "tag": "0001_authorization_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1743970780859,
+      "tag": "0002_seed_roles_permissions",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1743970780860,
+      "tag": "0004_keys_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1743970780861,
+      "tag": "0005_keys_schema_fix",
+      "breakpoints": true
     }
   ]
 }

--- a/src/services/credentials.service.ts
+++ b/src/services/credentials.service.ts
@@ -1,0 +1,337 @@
+/**
+ * Credentials Service
+ *
+ * This service provides methods for managing Open Badges credentials used in the application.
+ * It handles credential storage, verification, and status management.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "@/db/config";
+import { credentials } from "@/db/schema/credentials.schema";
+import logger from "@/utils/logger";
+import { type Logger as PinoLogger } from "pino";
+import { createHash } from "crypto";
+
+/**
+ * Type definitions for the credentials service
+ */
+export type Credential = typeof credentials.$inferSelect;
+export type NewCredential = Omit<
+  typeof credentials.$inferInsert,
+  "id" | "createdAt" | "issuedAt" | "isActive"
+>;
+export type CredentialUpdate = Partial<
+  Omit<typeof credentials.$inferInsert, "id" | "createdAt" | "issuedAt">
+>;
+
+/**
+ * Credential status enum
+ */
+export enum CredentialStatus {
+  ACTIVE = "active",
+  EXPIRED = "expired",
+  REVOKED = "revoked",
+  SUSPENDED = "suspended",
+}
+
+/**
+ * Verification result interface
+ */
+export interface VerificationResult {
+  valid: boolean;
+  checks: {
+    signature?: boolean;
+    revocation?: boolean;
+    expiration?: boolean;
+    structure?: boolean;
+    statusList?: boolean;
+    proof?: boolean;
+  };
+  errors: string[];
+  warnings?: string[];
+  details?: {
+    credentialId?: string;
+    issuerId?: string;
+    verificationMethod?: string;
+    proofType?: string;
+    statusListCredential?: string;
+    statusListIndex?: string;
+    cryptosuite?: string;
+  };
+}
+
+/**
+ * Credentials Service
+ */
+export class CredentialsService {
+  private logger: PinoLogger;
+
+  constructor() {
+    this.logger = logger.child({ context: "CredentialsService" });
+  }
+
+  /**
+   * Store a new credential
+   * @param data Credential data
+   * @returns Stored credential
+   */
+  async storeCredential(data: NewCredential): Promise<Credential> {
+    try {
+      this.logger.info({ type: data.type }, "Storing new credential");
+
+      const [credential] = await db
+        .insert(credentials)
+        .values({
+          ...data,
+          issuedAt: new Date(),
+          isActive: true,
+        })
+        .returning();
+
+      this.logger.info(
+        { credentialId: credential.id },
+        "Credential stored successfully",
+      );
+      return credential;
+    } catch (error) {
+      this.logger.error({ error, data }, "Failed to store credential");
+      throw new Error(
+        `Failed to store credential: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Get a credential by ID
+   * @param id Credential ID
+   * @returns Credential or null if not found
+   */
+  async getCredentialById(id: string): Promise<Credential | null> {
+    try {
+      const [credential] = await db
+        .select()
+        .from(credentials)
+        .where(eq(credentials.id, id))
+        .limit(1);
+
+      return credential || null;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to get credential by ID");
+      throw new Error(
+        `Failed to get credential by ID: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Verify a credential
+   * @param id Credential ID
+   * @returns Verification result
+   */
+  async verifyCredential(id: string): Promise<VerificationResult> {
+    try {
+      this.logger.info({ credentialId: id }, "Verifying credential");
+
+      const credential = await this.getCredentialById(id);
+      if (!credential) {
+        return {
+          valid: false,
+          checks: {},
+          errors: [`Credential with ID ${id} not found`],
+        };
+      }
+
+      // Initialize verification result
+      const result: VerificationResult = {
+        valid: false,
+        checks: {
+          structure: true,
+          revocation: true,
+          expiration: true,
+          proof: true, // Initialize proof check to true
+        },
+        errors: [],
+        details: {
+          credentialId: credential.id,
+          issuerId: credential.issuerId,
+        },
+      };
+
+      // Check if the credential is revoked
+      if (credential.revokedAt) {
+        result.checks.revocation = false;
+        result.errors.push(
+          `Credential was revoked on ${credential.revokedAt.toISOString()}`,
+        );
+      }
+
+      // Check if the credential is expired
+      if (credential.expiresAt && credential.expiresAt < new Date()) {
+        result.checks.expiration = false;
+        result.errors.push(
+          `Credential expired on ${credential.expiresAt.toISOString()}`,
+        );
+      }
+
+      // Check if the credential has a proof
+      if (!credential.proof) {
+        result.checks.proof = false;
+        result.errors.push("Credential does not have a proof");
+      }
+
+      // Determine if the credential is valid overall
+      result.valid = Object.values(result.checks).every(
+        (check) => check !== false,
+      );
+
+      return result;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to verify credential");
+      return {
+        valid: false,
+        checks: {},
+        errors: [
+          `Verification error: ${error instanceof Error ? error.message : String(error)}`,
+        ],
+      };
+    }
+  }
+
+  /**
+   * Update credential status
+   * @param id Credential ID
+   * @param status New status
+   * @param reason Optional reason for status change
+   * @returns Updated credential
+   */
+  async updateCredentialStatus(
+    id: string,
+    status: string,
+    reason?: string,
+  ): Promise<Credential> {
+    try {
+      this.logger.info(
+        { credentialId: id, status, reason },
+        "Updating credential status",
+      );
+
+      let updateData: CredentialUpdate = {
+        status,
+      };
+
+      // Handle specific status changes
+      if (status === CredentialStatus.REVOKED) {
+        updateData.isActive = false;
+        updateData.revokedAt = new Date();
+        updateData.revocationReason = reason;
+      } else if (status === CredentialStatus.SUSPENDED) {
+        updateData.isActive = false;
+      } else if (status === CredentialStatus.ACTIVE) {
+        updateData.isActive = true;
+      }
+
+      const [credential] = await db
+        .update(credentials)
+        .set(updateData)
+        .where(eq(credentials.id, id))
+        .returning();
+
+      if (!credential) {
+        throw new Error(`Credential with ID ${id} not found`);
+      }
+
+      this.logger.info(
+        { credentialId: id, status },
+        "Credential status updated successfully",
+      );
+      return credential;
+    } catch (error) {
+      this.logger.error(
+        { error, id, status },
+        "Failed to update credential status",
+      );
+      throw new Error(
+        `Failed to update credential status: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * List credentials by issuer
+   * @param issuerId Issuer ID
+   * @returns Array of credentials
+   */
+  async listCredentialsByIssuer(issuerId: string): Promise<Credential[]> {
+    try {
+      return await db
+        .select()
+        .from(credentials)
+        .where(eq(credentials.issuerId, issuerId));
+    } catch (error) {
+      this.logger.error(
+        { error, issuerId },
+        "Failed to list credentials by issuer",
+      );
+      throw new Error(
+        `Failed to list credentials by issuer: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * List credentials by recipient
+   * @param recipientId Recipient ID
+   * @returns Array of credentials
+   */
+  async listCredentialsByRecipient(recipientId: string): Promise<Credential[]> {
+    try {
+      return await db
+        .select()
+        .from(credentials)
+        .where(eq(credentials.recipientId, recipientId));
+    } catch (error) {
+      this.logger.error(
+        { error, recipientId },
+        "Failed to list credentials by recipient",
+      );
+      throw new Error(
+        `Failed to list credentials by recipient: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Check if a credential is revoked
+   * @param id Credential ID
+   * @returns Boolean indicating if the credential is revoked
+   */
+  async isCredentialRevoked(id: string): Promise<boolean> {
+    try {
+      const credential = await this.getCredentialById(id);
+      if (!credential) {
+        throw new Error(`Credential with ID ${id} not found`);
+      }
+
+      return (
+        !!credential.revokedAt || credential.status === CredentialStatus.REVOKED
+      );
+    } catch (error) {
+      this.logger.error(
+        { error, id },
+        "Failed to check if credential is revoked",
+      );
+      throw new Error(
+        `Failed to check if credential is revoked: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Hash a credential for verification
+   * @param credentialData Credential data as JSON string
+   * @returns Credential hash
+   */
+  hashCredential(credentialData: string): string {
+    return createHash("sha256").update(credentialData).digest("hex");
+  }
+}

--- a/src/services/keys.service.ts
+++ b/src/services/keys.service.ts
@@ -1,0 +1,320 @@
+/**
+ * Keys Service
+ *
+ * This service provides methods for managing cryptographic keys used in the application.
+ * It handles key creation, retrieval, rotation, and revocation.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/config";
+import { keys } from "@/db/schema/keys.schema";
+import logger from "@/utils/logger";
+import { type Logger as PinoLogger } from "pino";
+
+/**
+ * Type definitions for the keys service
+ */
+export type Key = typeof keys.$inferSelect;
+export type NewKey = Omit<
+  typeof keys.$inferInsert,
+  "id" | "createdAt" | "isActive"
+>;
+export type KeyUpdate = Partial<
+  Omit<typeof keys.$inferInsert, "id" | "createdAt">
+>;
+
+/**
+ * Key status enum
+ */
+export enum KeyStatus {
+  ACTIVE = "active",
+  EXPIRED = "expired",
+  REVOKED = "revoked",
+}
+
+/**
+ * Keys Service
+ */
+export class KeysService {
+  private logger: PinoLogger;
+
+  constructor() {
+    this.logger = logger.child({ context: "KeysService" });
+  }
+
+  /**
+   * Create a new key
+   * @param data Key data
+   * @returns Created key
+   */
+  async createKey(data: NewKey): Promise<Key> {
+    try {
+      this.logger.info({ type: data.type }, "Creating new key");
+
+      const [key] = await db
+        .insert(keys)
+        .values({
+          ...data,
+          isActive: true,
+        })
+        .returning();
+
+      this.logger.info({ keyId: key.id }, "Key created successfully");
+      return key;
+    } catch (error) {
+      this.logger.error({ error, data }, "Failed to create key");
+      throw new Error(
+        `Failed to create key: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Get a key by ID
+   * @param id Key ID
+   * @returns Key or null if not found
+   */
+  async getKeyById(id: string): Promise<Key | null> {
+    try {
+      const result = await db.select().from(keys).where(eq(keys.id, id));
+
+      return result[0] || null;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to get key by ID");
+      throw new Error(
+        `Failed to get key by ID: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * List keys by type
+   * @param type Key type
+   * @param includeInactive Whether to include inactive keys
+   * @returns Array of keys
+   */
+  async listKeysByType(
+    type: string,
+    includeInactive: boolean = false,
+  ): Promise<Key[]> {
+    try {
+      if (includeInactive) {
+        return await db.select().from(keys).where(eq(keys.type, type));
+      } else {
+        return await db
+          .select()
+          .from(keys)
+          .where(and(eq(keys.type, type), eq(keys.isActive, true)));
+      }
+    } catch (error) {
+      this.logger.error({ error, type }, "Failed to list keys by type");
+      throw new Error(
+        `Failed to list keys by type: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Update a key
+   * @param id Key ID
+   * @param data Key data to update
+   * @returns Updated key
+   */
+  async updateKey(id: string, data: KeyUpdate): Promise<Key> {
+    try {
+      this.logger.info({ keyId: id }, "Updating key");
+
+      const [key] = await db
+        .update(keys)
+        .set(data)
+        .where(eq(keys.id, id))
+        .returning();
+
+      if (!key) {
+        throw new Error(`Key with ID ${id} not found`);
+      }
+
+      this.logger.info({ keyId: id }, "Key updated successfully");
+      return key;
+    } catch (error) {
+      this.logger.error({ error, id, data }, "Failed to update key");
+      throw new Error(
+        `Failed to update key: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Revoke a key
+   * @param id Key ID
+   * @param reason Revocation reason
+   * @returns Void
+   */
+  async revokeKey(id: string, reason?: string): Promise<void> {
+    try {
+      this.logger.info({ keyId: id, reason }, "Revoking key");
+
+      const [key] = await db
+        .update(keys)
+        .set({
+          isActive: false,
+          revokedAt: new Date(),
+          revocationReason: reason,
+        })
+        .where(eq(keys.id, id))
+        .returning();
+
+      if (!key) {
+        throw new Error(`Key with ID ${id} not found`);
+      }
+
+      this.logger.info({ keyId: id }, "Key revoked successfully");
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to revoke key");
+      throw new Error(
+        `Failed to revoke key: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Rotate a key (create new version, mark old as previous)
+   * @param id Key ID to rotate
+   * @returns New key
+   */
+  async rotateKey(id: string): Promise<Key> {
+    try {
+      this.logger.info({ keyId: id }, "Rotating key");
+
+      // Get the old key
+      const oldKey = await this.getKeyById(id);
+      if (!oldKey) {
+        throw new Error(`Key with ID ${id} not found`);
+      }
+
+      // Create a new key with the same properties
+      const newKey = await this.createKey({
+        type: oldKey.type,
+        algorithm: oldKey.algorithm,
+        publicKey: oldKey.publicKey,
+        privateKey: oldKey.privateKey,
+        name: oldKey.name,
+        description: oldKey.description,
+        version: this.generateNewVersion(oldKey.version),
+        previousKeyId: oldKey.id,
+      });
+
+      // Update the old key to be inactive
+      await this.updateKey(oldKey.id, {
+        isActive: false,
+      });
+
+      this.logger.info(
+        { oldKeyId: oldKey.id, newKeyId: newKey.id },
+        "Key rotated successfully",
+      );
+      return newKey;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to rotate key");
+      throw new Error(
+        `Failed to rotate key: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Check if a key is active
+   * @param id Key ID
+   * @returns Boolean indicating if the key is active
+   */
+  async isKeyActive(id: string): Promise<boolean> {
+    try {
+      const key = await this.getKeyById(id);
+      if (!key) {
+        return false;
+      }
+
+      // Check if the key is active
+      if (!key.isActive) {
+        return false;
+      }
+
+      // Check if the key is expired
+      if (key.expiresAt && key.expiresAt < new Date()) {
+        return false;
+      }
+
+      // Check if the key is revoked
+      if (key.revokedAt) {
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to check if key is active");
+      throw new Error(
+        `Failed to check if key is active: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Get key status
+   * @param id Key ID
+   * @returns Key status
+   */
+  async getKeyStatus(id: string): Promise<KeyStatus> {
+    try {
+      const key = await this.getKeyById(id);
+      if (!key) {
+        throw new Error(`Key with ID ${id} not found`);
+      }
+
+      // Check if the key is revoked
+      if (key.revokedAt) {
+        return KeyStatus.REVOKED;
+      }
+
+      // Check if the key is expired
+      if (key.expiresAt && key.expiresAt < new Date()) {
+        return KeyStatus.EXPIRED;
+      }
+
+      // Check if the key is active
+      if (!key.isActive) {
+        return KeyStatus.REVOKED;
+      }
+
+      return KeyStatus.ACTIVE;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to get key status");
+      throw new Error(
+        `Failed to get key status: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Generate a new version string based on the old version
+   * @param currentVersion Current version string
+   * @returns New version string
+   */
+  private generateNewVersion(currentVersion?: string | null): string {
+    if (!currentVersion) {
+      return "1.0.0";
+    }
+
+    // Parse the version string
+    const versionParts = currentVersion.split(".");
+    if (versionParts.length !== 3) {
+      return "1.0.0";
+    }
+
+    // Increment the patch version
+    const major = parseInt(versionParts[0], 10);
+    const minor = parseInt(versionParts[1], 10);
+    const patch = parseInt(versionParts[2], 10) + 1;
+
+    return `${major}.${minor}.${patch}`;
+  }
+}

--- a/src/services/tokens.service.ts
+++ b/src/services/tokens.service.ts
@@ -1,0 +1,276 @@
+/**
+ * Tokens Service
+ *
+ * This service provides methods for managing OAuth tokens used in the application.
+ * It handles token creation, verification, revocation, and status checking.
+ */
+
+import { eq, and, gt, lt, isNull, or, not } from "drizzle-orm";
+import { db } from "@/db/config";
+import { tokens } from "@/db/schema/tokens.schema";
+import logger from "@/utils/logger";
+import { type Logger as PinoLogger } from "pino";
+import { createHash } from "crypto";
+
+/**
+ * Type definitions for the tokens service
+ */
+export type Token = typeof tokens.$inferSelect;
+export type NewToken = Omit<
+  typeof tokens.$inferInsert,
+  "id" | "createdAt" | "isActive"
+>;
+export type TokenUpdate = Partial<
+  Omit<typeof tokens.$inferInsert, "id" | "createdAt">
+>;
+
+/**
+ * Token status enum
+ */
+export enum TokenStatus {
+  ACTIVE = "active",
+  EXPIRED = "expired",
+  REVOKED = "revoked",
+}
+
+/**
+ * Tokens Service
+ */
+export class TokensService {
+  private logger: PinoLogger;
+
+  constructor() {
+    this.logger = logger.child({ context: "TokensService" });
+  }
+
+  /**
+   * Create a new token
+   * @param data Token data
+   * @returns Created token
+   */
+  async createToken(data: NewToken): Promise<Token> {
+    try {
+      this.logger.info({ type: data.type }, "Creating new token");
+
+      const [token] = await db
+        .insert(tokens)
+        .values({
+          ...data,
+          isActive: true,
+        })
+        .returning();
+
+      this.logger.info({ tokenId: token.id }, "Token created successfully");
+      return token;
+    } catch (error) {
+      this.logger.error({ error, data }, "Failed to create token");
+      throw new Error(
+        `Failed to create token: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Get a token by ID
+   * @param id Token ID
+   * @returns Token or null if not found
+   */
+  async getTokenById(id: string): Promise<Token | null> {
+    try {
+      const [token] = await db
+        .select()
+        .from(tokens)
+        .where(eq(tokens.id, id))
+        .limit(1);
+
+      return token || null;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to get token by ID");
+      throw new Error(
+        `Failed to get token by ID: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Verify a token by its hash
+   * @param tokenHash Token hash
+   * @returns Token or null if not found or invalid
+   */
+  async verifyToken(tokenHash: string): Promise<Token | null> {
+    try {
+      const [token] = await db
+        .select()
+        .from(tokens)
+        .where(
+          and(
+            eq(tokens.tokenHash, tokenHash),
+            eq(tokens.isActive, true),
+            gt(tokens.expiresAt, new Date()),
+            isNull(tokens.revokedAt),
+          ),
+        )
+        .limit(1);
+
+      return token || null;
+    } catch (error) {
+      this.logger.error({ error }, "Failed to verify token");
+      throw new Error(
+        `Failed to verify token: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Revoke a token
+   * @param id Token ID
+   * @param reason Revocation reason
+   * @returns Void
+   */
+  async revokeToken(id: string, reason?: string): Promise<void> {
+    try {
+      this.logger.info({ tokenId: id, reason }, "Revoking token");
+
+      const [token] = await db
+        .update(tokens)
+        .set({
+          isActive: false,
+          revokedAt: new Date(),
+          revocationReason: reason,
+        })
+        .where(eq(tokens.id, id))
+        .returning();
+
+      if (!token) {
+        throw new Error(`Token with ID ${id} not found`);
+      }
+
+      this.logger.info({ tokenId: id }, "Token revoked successfully");
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to revoke token");
+      throw new Error(
+        `Failed to revoke token: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Get token status
+   * @param id Token ID
+   * @returns Token status
+   */
+  async getTokenStatus(id: string): Promise<TokenStatus> {
+    try {
+      const token = await this.getTokenById(id);
+      if (!token) {
+        throw new Error(`Token with ID ${id} not found`);
+      }
+
+      // Check if the token is revoked
+      if (token.revokedAt) {
+        return TokenStatus.REVOKED;
+      }
+
+      // Check if the token is expired
+      if (token.expiresAt < new Date()) {
+        return TokenStatus.EXPIRED;
+      }
+
+      // Check if the token is active
+      if (!token.isActive) {
+        return TokenStatus.REVOKED;
+      }
+
+      return TokenStatus.ACTIVE;
+    } catch (error) {
+      this.logger.error({ error, id }, "Failed to get token status");
+      throw new Error(
+        `Failed to get token status: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * List active tokens for a user
+   * @param userId User ID
+   * @param clientId Optional client ID to filter by
+   * @returns Array of active tokens
+   */
+  async listActiveTokens(userId: string, clientId?: string): Promise<Token[]> {
+    try {
+      let query = db
+        .select()
+        .from(tokens)
+        .where(
+          and(
+            eq(tokens.userId, userId),
+            eq(tokens.isActive, true),
+            gt(tokens.expiresAt, new Date()),
+            isNull(tokens.revokedAt),
+          ),
+        );
+
+      if (clientId) {
+        return await db
+          .select()
+          .from(tokens)
+          .where(
+            and(
+              eq(tokens.userId, userId),
+              eq(tokens.isActive, true),
+              gt(tokens.expiresAt, new Date()),
+              isNull(tokens.revokedAt),
+              eq(tokens.clientId, clientId),
+            ),
+          );
+      }
+
+      return await query;
+    } catch (error) {
+      this.logger.error(
+        { error, userId, clientId },
+        "Failed to list active tokens",
+      );
+      throw new Error(
+        `Failed to list active tokens: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Clean up expired tokens
+   * @returns Number of tokens removed
+   */
+  async cleanupExpiredTokens(): Promise<number> {
+    try {
+      this.logger.info("Cleaning up expired tokens");
+
+      const result = await db
+        .delete(tokens)
+        .where(
+          or(
+            lt(tokens.expiresAt, new Date()),
+            and(eq(tokens.isActive, false), not(isNull(tokens.revokedAt))),
+          ),
+        );
+
+      const count = result.rowCount || 0;
+      this.logger.info({ count }, "Expired tokens cleaned up successfully");
+      return count;
+    } catch (error) {
+      this.logger.error({ error }, "Failed to clean up expired tokens");
+      throw new Error(
+        `Failed to clean up expired tokens: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Hash a token for secure storage
+   * @param token Raw token string
+   * @returns Hashed token
+   */
+  hashToken(token: string): string {
+    return createHash("sha256").update(token).digest("hex");
+  }
+}

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,6 +1,5 @@
 import { swaggerUI } from "@hono/swagger-ui";
 import { Hono } from "hono";
-import type { Context } from "hono";
 
 // Environment variables for server URL construction
 const hostEnv = process.env.HOST || "localhost"; // Use HOST env var or default to localhost for Swagger URL
@@ -247,9 +246,17 @@ export const swaggerDefinition = {
 export const createSwaggerUI = () => {
   const app = new Hono();
 
+  // Serves the raw OpenAPI JSON spec (relative path: ./openapi.json)
   app.get("/openapi.json", (c) => c.json(swaggerDefinition));
-  app.get("/", (c: Context) => c.redirect(`${serverUrl}/ui`));
-  app.use("/ui", swaggerUI({ url: `${serverUrl}/openapi.json` }));
+
+  // Serves the Swagger UI interface at the root of this sub-app ('/')
+  // When mounted at /docs, this becomes the handler for /docs
+  app.get(
+    "/", // Serve UI at the root of this Hono instance
+    swaggerUI({
+      url: "/docs/openapi.json", // Absolute path to the JSON spec
+    }),
+  );
 
   return app;
 };

--- a/tests/integration/services/authorization.service.integration.test.ts
+++ b/tests/integration/services/authorization.service.integration.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { authorizationService } from "../../../src/services/authorization.service";
-import { db } from "../../../src/db/config";
-import { users } from "../../../src/db/schema";
+import { authorizationService } from "@services/authorization.service";
+import { db } from "@/db/config";
+import { users } from "@/db/schema";
+import { userRoles, userPermissions } from "@/db/schema/roles.schema";
 // Role enum is not needed as we're using string literals
-import { Permission } from "../../../src/models/auth/roles";
+import { Permission } from "@models/auth/roles";
 import { randomUUID } from "crypto";
 import { eq } from "drizzle-orm";
 
@@ -26,8 +27,16 @@ describe("AuthorizationService Integration Tests", () => {
 
   // Clean up after all tests
   afterAll(async () => {
-    // Delete the test user
     if (testUserId) {
+      // Delete associated roles first
+      await db.delete(userRoles).where(eq(userRoles.userId, testUserId));
+
+      // Delete associated direct permissions
+      await db
+        .delete(userPermissions)
+        .where(eq(userPermissions.userId, testUserId));
+
+      // Finally, delete the test user
       await db.delete(users).where(eq(users.userId, testUserId));
     }
   });

--- a/tests/integration/services/credentials.service.integration.test.ts
+++ b/tests/integration/services/credentials.service.integration.test.ts
@@ -1,0 +1,315 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "bun:test";
+import {
+  CredentialsService,
+  CredentialStatus,
+} from "@/services/credentials.service";
+import { db } from "@/db/config";
+import { credentials } from "@/db/schema/credentials.schema";
+import { eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import "@/utils/test/integration-setup";
+
+describe("CredentialsService Integration", () => {
+  let credentialsService: CredentialsService;
+  let testCredentialId: string;
+  const testIssuerId = "test-issuer-id";
+  const testRecipientId = "test-recipient-id";
+  const testKeyId = "test-key-id";
+
+  // Create the credentials table if it doesn't exist
+  beforeAll(async () => {
+    try {
+      // Check if the credentials table exists
+      const result = await db.execute(sql`
+        SELECT EXISTS (
+          SELECT FROM pg_tables
+          WHERE schemaname = 'public'
+          AND tablename = 'credentials'
+        );
+      `);
+
+      const tableExists = result.rows[0]?.exists;
+      if (!tableExists) {
+        console.log("Creating credentials table for tests...");
+        await db.execute(sql`
+          CREATE TABLE IF NOT EXISTS credentials (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            issuer_id TEXT NOT NULL,
+            recipient_id TEXT NOT NULL,
+            credential_hash TEXT NOT NULL,
+            data JSONB,
+            proof JSONB,
+            key_id TEXT,
+            status TEXT NOT NULL,
+            expires_at TIMESTAMP WITH TIME ZONE,
+            revoked_at TIMESTAMP WITH TIME ZONE,
+            revocation_reason TEXT,
+            is_active BOOLEAN NOT NULL DEFAULT true,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+            issued_at TIMESTAMP WITH TIME ZONE NOT NULL
+          );
+        `);
+        console.log("✅ Credentials table created successfully");
+      } else {
+        console.log("Credentials table already exists");
+      }
+    } catch (error) {
+      console.error("Error setting up credentials table:", error);
+      throw error;
+    }
+  });
+
+  beforeEach(async () => {
+    credentialsService = new CredentialsService();
+
+    // Clean up any existing test credentials
+    try {
+      await db
+        .delete(credentials)
+        .where(eq(credentials.issuerId, testIssuerId));
+    } catch (error) {
+      console.error("Error cleaning up existing test credentials:", error);
+    }
+
+    // Create a test credential for use in tests
+    try {
+      const [testCredential] = await db
+        .insert(credentials)
+        .values({
+          type: "OpenBadgeCredential",
+          issuerId: testIssuerId,
+          recipientId: testRecipientId,
+          credentialHash: "test-credential-hash",
+          data: { test: "data" },
+          proof: { test: "proof" },
+          keyId: testKeyId,
+          status: "active",
+          issuedAt: new Date(),
+          isActive: true,
+        })
+        .returning();
+
+      testCredentialId = testCredential.id;
+    } catch (error) {
+      console.error("Error creating test credential:", error);
+      throw error;
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up test credentials
+    try {
+      await db
+        .delete(credentials)
+        .where(eq(credentials.issuerId, testIssuerId));
+    } catch (error) {
+      console.error("Error cleaning up test credentials:", error);
+    }
+  });
+
+  // Clean up after all tests
+  afterAll(async () => {
+    try {
+      // Delete all test data
+      await db
+        .delete(credentials)
+        .where(eq(credentials.issuerId, testIssuerId));
+    } catch (error) {
+      console.error("Error cleaning up after tests:", error);
+    }
+  });
+
+  test("should store a new credential", async () => {
+    const credentialData = {
+      type: "VerifiableCredential",
+      issuerId: testIssuerId,
+      recipientId: "new-test-recipient-id",
+      credentialHash: "new-test-credential-hash",
+      data: { test: "new-data" },
+      proof: { test: "new-proof" },
+      keyId: testKeyId,
+      status: "active",
+    };
+
+    const credential = await credentialsService.storeCredential(credentialData);
+
+    expect(credential).toBeDefined();
+    expect(credential.id).toBeDefined();
+    expect(credential.type).toBe("VerifiableCredential");
+    expect(credential.issuerId).toBe(testIssuerId);
+    expect(credential.recipientId).toBe("new-test-recipient-id");
+    expect(credential.credentialHash).toBe("new-test-credential-hash");
+    expect(credential.data).toEqual({ test: "new-data" });
+    expect(credential.proof).toEqual({ test: "new-proof" });
+    expect(credential.keyId).toBe(testKeyId);
+    expect(credential.status).toBe("active");
+    expect(credential.isActive).toBe(true);
+    expect(credential.issuedAt).toBeDefined();
+
+    // Clean up the created credential
+    await db.delete(credentials).where(eq(credentials.id, credential.id));
+  });
+
+  test("should get a credential by ID", async () => {
+    const credential =
+      await credentialsService.getCredentialById(testCredentialId);
+
+    expect(credential).toBeDefined();
+    expect(credential?.id).toBe(testCredentialId);
+    expect(credential?.type).toBe("OpenBadgeCredential");
+    expect(credential?.issuerId).toBe(testIssuerId);
+    expect(credential?.recipientId).toBe(testRecipientId);
+    expect(credential?.credentialHash).toBe("test-credential-hash");
+    expect(credential?.data).toEqual({ test: "data" });
+    expect(credential?.proof).toEqual({ test: "proof" });
+    expect(credential?.keyId).toBe(testKeyId);
+    expect(credential?.status).toBe("active");
+    expect(credential?.isActive).toBe(true);
+  });
+
+  test("should verify a credential", async () => {
+    const result = await credentialsService.verifyCredential(testCredentialId);
+
+    expect(result).toBeDefined();
+    expect(result.valid).toBe(true);
+    expect(result.checks.structure).toBe(true);
+    expect(result.checks.revocation).toBe(true);
+    expect(result.checks.proof).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.details?.credentialId).toBe(testCredentialId);
+    expect(result.details?.issuerId).toBe(testIssuerId);
+  });
+
+  test("should update credential status", async () => {
+    const credential = await credentialsService.updateCredentialStatus(
+      testCredentialId,
+      CredentialStatus.REVOKED,
+      "Test revocation",
+    );
+
+    expect(credential).toBeDefined();
+    expect(credential.id).toBe(testCredentialId);
+    expect(credential.status).toBe("revoked");
+    expect(credential.revokedAt).toBeDefined();
+    expect(credential.revocationReason).toBe("Test revocation");
+    expect(credential.isActive).toBe(false);
+
+    // Verify the credential
+    const result = await credentialsService.verifyCredential(testCredentialId);
+    expect(result.valid).toBe(false);
+    expect(result.checks.revocation).toBe(false);
+  });
+
+  test("should list credentials by issuer", async () => {
+    // Create a second credential for the same issuer
+    await credentialsService.storeCredential({
+      type: "VerifiableCredential",
+      issuerId: testIssuerId,
+      recipientId: "second-test-recipient-id",
+      credentialHash: "second-test-credential-hash",
+      data: { test: "second-data" },
+      proof: { test: "second-proof" },
+      keyId: testKeyId,
+      status: "active",
+    });
+
+    const credentials =
+      await credentialsService.listCredentialsByIssuer(testIssuerId);
+
+    expect(credentials).toBeDefined();
+    expect(credentials.length).toBeGreaterThanOrEqual(2);
+
+    // Find our test credentials in the results
+    const originalCredential = credentials.find(
+      (c) => c.id === testCredentialId,
+    );
+    expect(originalCredential).toBeDefined();
+    expect(originalCredential?.recipientId).toBe(testRecipientId);
+
+    const secondCredential = credentials.find(
+      (c) => c.recipientId === "second-test-recipient-id",
+    );
+    expect(secondCredential).toBeDefined();
+    expect(secondCredential?.type).toBe("VerifiableCredential");
+  });
+
+  test("should list credentials by recipient", async () => {
+    // Create a second credential for the same recipient
+    await credentialsService.storeCredential({
+      type: "VerifiableCredential",
+      issuerId: "second-test-issuer-id",
+      recipientId: testRecipientId,
+      credentialHash: "second-test-credential-hash",
+      data: { test: "second-data" },
+      proof: { test: "second-proof" },
+      keyId: testKeyId,
+      status: "active",
+    });
+
+    const credentials =
+      await credentialsService.listCredentialsByRecipient(testRecipientId);
+
+    expect(credentials).toBeDefined();
+    expect(credentials.length).toBeGreaterThanOrEqual(2);
+
+    // Find our test credentials in the results
+    const originalCredential = credentials.find(
+      (c) => c.id === testCredentialId,
+    );
+    expect(originalCredential).toBeDefined();
+    expect(originalCredential?.issuerId).toBe(testIssuerId);
+
+    const secondCredential = credentials.find(
+      (c) => c.issuerId === "second-test-issuer-id",
+    );
+    expect(secondCredential).toBeDefined();
+    expect(secondCredential?.type).toBe("VerifiableCredential");
+
+    // Note: The second credential will be cleaned up in afterEach
+  });
+
+  test("should check if a credential is revoked", async () => {
+    // First check a non-revoked credential
+    let isRevoked =
+      await credentialsService.isCredentialRevoked(testCredentialId);
+    expect(isRevoked).toBe(false);
+
+    // Now revoke the credential and check again
+    await credentialsService.updateCredentialStatus(
+      testCredentialId,
+      CredentialStatus.REVOKED,
+      "Test revocation",
+    );
+
+    isRevoked = await credentialsService.isCredentialRevoked(testCredentialId);
+    expect(isRevoked).toBe(true);
+  });
+
+  test("should hash a credential", () => {
+    const credentialData = JSON.stringify({ test: "credential" });
+    const hash = credentialsService.hashCredential(credentialData);
+
+    expect(hash).toBeDefined();
+    expect(typeof hash).toBe("string");
+    expect(hash.length).toBe(64); // SHA-256 hash is 64 characters in hex
+
+    // Verify the hash is consistent
+    const hash2 = credentialsService.hashCredential(credentialData);
+    expect(hash).toBe(hash2);
+
+    // Verify different credentials produce different hashes
+    const hash3 = credentialsService.hashCredential(
+      JSON.stringify({ test: "different" }),
+    );
+    expect(hash).not.toBe(hash3);
+  });
+});

--- a/tests/integration/services/keys.service.integration.test.ts
+++ b/tests/integration/services/keys.service.integration.test.ts
@@ -1,0 +1,201 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "bun:test";
+import { KeysService, KeyStatus } from "@/services/keys.service";
+import { db } from "@/db/config";
+import { keys } from "@/db/schema/keys.schema";
+import { eq } from "drizzle-orm";
+import "@/utils/test/integration-setup";
+
+describe("KeysService Integration", () => {
+  let keysService: KeysService;
+  let testKeyId: string;
+
+  // Setup before all tests
+  beforeAll(async () => {
+    // We'll use the existing database setup from the test environment
+    // No need to create tables manually as they should already exist
+  });
+
+  beforeEach(async () => {
+    keysService = new KeysService();
+
+    // Clean up any existing test keys
+    try {
+      await db.delete(keys).where(eq(keys.name, "Test Key"));
+    } catch (error) {
+      console.error("Error cleaning up existing test keys:", error);
+    }
+
+    // Create a test key for use in tests
+    try {
+      const [testKey] = await db
+        .insert(keys)
+        .values({
+          type: "signing",
+          algorithm: "RS256",
+          publicKey: "test-public-key",
+          privateKey: "test-private-key",
+          name: "Test Key",
+          description: "Test key for integration tests",
+          version: "1.0.0",
+          isActive: true,
+        })
+        .returning();
+
+      testKeyId = testKey.id;
+    } catch (error) {
+      console.error("Error creating test key:", error);
+      throw error;
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up test keys
+    try {
+      await db.delete(keys).where(eq(keys.name, "Test Key"));
+    } catch (error) {
+      console.error("Error cleaning up test keys:", error);
+    }
+  });
+
+  // Clean up after all tests
+  afterAll(async () => {
+    try {
+      // Delete all test data
+      await db.delete(keys).where(eq(keys.name, "Test Key"));
+    } catch (error) {
+      console.error("Error cleaning up after tests:", error);
+    }
+  });
+
+  test("should create a new key", async () => {
+    const keyData = {
+      type: "verification",
+      algorithm: "ES256",
+      publicKey: "new-test-public-key",
+      privateKey: "new-test-private-key",
+      name: "Test Key",
+      description: "New test key for integration tests",
+      version: "1.0.0",
+    };
+
+    const key = await keysService.createKey(keyData);
+
+    expect(key).toBeDefined();
+    expect(key.id).toBeDefined();
+    expect(key.type).toBe("verification");
+    expect(key.algorithm).toBe("ES256");
+    expect(key.publicKey).toBe("new-test-public-key");
+    expect(key.privateKey).toBe("new-test-private-key");
+    expect(key.name).toBe("Test Key");
+    expect(key.description).toBe("New test key for integration tests");
+    expect(key.isActive).toBe(true);
+
+    // Clean up the created key
+    await db.delete(keys).where(eq(keys.id, key.id));
+  });
+
+  test("should get a key by ID", async () => {
+    const key = await keysService.getKeyById(testKeyId);
+
+    expect(key).toBeDefined();
+    expect(key?.id).toBe(testKeyId);
+    expect(key?.type).toBe("signing");
+    expect(key?.algorithm).toBe("RS256");
+    expect(key?.publicKey).toBe("test-public-key");
+    expect(key?.privateKey).toBe("test-private-key");
+    expect(key?.name).toBe("Test Key");
+    expect(key?.description).toBe("Test key for integration tests");
+    expect(key?.isActive).toBe(true);
+  });
+
+  test("should list keys by type", async () => {
+    const keys = await keysService.listKeysByType("signing");
+
+    expect(keys).toBeDefined();
+    expect(keys.length).toBeGreaterThanOrEqual(1);
+
+    // Find our test key in the results
+    const testKey = keys.find((k) => k.id === testKeyId);
+    expect(testKey).toBeDefined();
+    expect(testKey?.type).toBe("signing");
+    expect(testKey?.algorithm).toBe("RS256");
+    expect(testKey?.name).toBe("Test Key");
+  });
+
+  test("should update a key", async () => {
+    const keyData = {
+      name: "Updated Test Key",
+      description: "Updated test key for integration tests",
+    };
+
+    const key = await keysService.updateKey(testKeyId, keyData);
+
+    expect(key).toBeDefined();
+    expect(key.id).toBe(testKeyId);
+    expect(key.name).toBe("Updated Test Key");
+    expect(key.description).toBe("Updated test key for integration tests");
+  });
+
+  test("should revoke a key", async () => {
+    await keysService.revokeKey(testKeyId, "Test revocation");
+
+    const key = await keysService.getKeyById(testKeyId);
+    expect(key).toBeDefined();
+    expect(key?.isActive).toBe(false);
+    expect(key?.revokedAt).toBeDefined();
+    expect(key?.revocationReason).toBe("Test revocation");
+  });
+
+  test("should rotate a key", async () => {
+    const newKey = await keysService.rotateKey(testKeyId);
+
+    expect(newKey).toBeDefined();
+    expect(newKey.id).not.toBe(testKeyId);
+    expect(newKey.type).toBe("signing");
+    expect(newKey.algorithm).toBe("RS256");
+    expect(newKey.publicKey).toBe("test-public-key");
+    expect(newKey.privateKey).toBe("test-private-key");
+    expect(newKey.name).toBe("Test Key");
+    expect(newKey.description).toBe("Test key for integration tests");
+    expect(newKey.isActive).toBe(true);
+    expect(newKey.previousKeyId).toBe(testKeyId);
+
+    // Check that the old key is now inactive
+    const oldKey = await keysService.getKeyById(testKeyId);
+    expect(oldKey).toBeDefined();
+    expect(oldKey?.isActive).toBe(false);
+
+    // Clean up the new key
+    await db.delete(keys).where(eq(keys.id, newKey.id));
+  });
+
+  test("should check if a key is active", async () => {
+    // First check an active key
+    let isActive = await keysService.isKeyActive(testKeyId);
+    expect(isActive).toBe(true);
+
+    // Now revoke the key and check again
+    await keysService.revokeKey(testKeyId, "Test revocation");
+    isActive = await keysService.isKeyActive(testKeyId);
+    expect(isActive).toBe(false);
+  });
+
+  test("should get key status", async () => {
+    // First check an active key
+    let status = await keysService.getKeyStatus(testKeyId);
+    expect(status).toBe(KeyStatus.ACTIVE);
+
+    // Now revoke the key and check again
+    await keysService.revokeKey(testKeyId, "Test revocation");
+    status = await keysService.getKeyStatus(testKeyId);
+    expect(status).toBe(KeyStatus.REVOKED);
+  });
+});

--- a/tests/integration/services/tokens.service.integration.test.ts
+++ b/tests/integration/services/tokens.service.integration.test.ts
@@ -1,0 +1,288 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "bun:test";
+import { TokensService, TokenStatus } from "@/services/tokens.service";
+import { db } from "@/db/config";
+import { tokens } from "@/db/schema/tokens.schema";
+import { eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import "@/utils/test/integration-setup";
+
+describe("TokensService Integration", () => {
+  let tokensService: TokensService;
+  let testTokenId: string;
+  let testTokenHash: string;
+  const testUserId = "test-user-id";
+  const testClientId = "test-client-id";
+
+  // Create the tokens table if it doesn't exist
+  beforeAll(async () => {
+    try {
+      // Check if the tokens table exists
+      const result = await db.execute(sql`
+        SELECT EXISTS (
+          SELECT FROM pg_tables
+          WHERE schemaname = 'public'
+          AND tablename = 'tokens'
+        );
+      `);
+
+      const tableExists = result.rows[0]?.exists;
+      if (!tableExists) {
+        console.log("Creating tokens table for tests...");
+        await db.execute(sql`
+          CREATE TABLE IF NOT EXISTS tokens (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            token_hash TEXT NOT NULL,
+            client_id TEXT,
+            user_id TEXT,
+            scope TEXT,
+            jwt_id TEXT,
+            expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+            revoked_at TIMESTAMP WITH TIME ZONE,
+            revocation_reason TEXT,
+            is_active BOOLEAN NOT NULL DEFAULT true,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+          );
+        `);
+        console.log("✅ Tokens table created successfully");
+      } else {
+        console.log("Tokens table already exists");
+      }
+    } catch (error) {
+      console.error("Error setting up tokens table:", error);
+      throw error;
+    }
+  });
+
+  beforeEach(async () => {
+    tokensService = new TokensService();
+    testTokenHash = tokensService.hashToken("test-token");
+
+    // Clean up any existing test tokens
+    try {
+      await db.delete(tokens).where(eq(tokens.userId, testUserId));
+    } catch (error) {
+      console.error("Error cleaning up existing test tokens:", error);
+    }
+
+    // Create a test token for use in tests
+    try {
+      const [testToken] = await db
+        .insert(tokens)
+        .values({
+          type: "access",
+          tokenHash: testTokenHash,
+          clientId: testClientId,
+          userId: testUserId,
+          scope: "read write",
+          jwtId: "test-jwt-id",
+          expiresAt: new Date(Date.now() + 3600000), // 1 hour from now
+          isActive: true,
+        })
+        .returning();
+
+      testTokenId = testToken.id;
+    } catch (error) {
+      console.error("Error creating test token:", error);
+      throw error;
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up test tokens
+    try {
+      await db.delete(tokens).where(eq(tokens.userId, testUserId));
+    } catch (error) {
+      console.error("Error cleaning up test tokens:", error);
+    }
+  });
+
+  // Clean up after all tests
+  afterAll(async () => {
+    try {
+      // Delete all test data
+      await db.delete(tokens).where(eq(tokens.userId, testUserId));
+    } catch (error) {
+      console.error("Error cleaning up after tests:", error);
+    }
+  });
+
+  test("should create a new token", async () => {
+    const tokenData = {
+      type: "refresh",
+      tokenHash: tokensService.hashToken("new-test-token"),
+      clientId: testClientId,
+      userId: testUserId,
+      scope: "read",
+      jwtId: "new-test-jwt-id",
+      expiresAt: new Date(Date.now() + 86400000), // 24 hours from now
+    };
+
+    const token = await tokensService.createToken(tokenData);
+
+    expect(token).toBeDefined();
+    expect(token.id).toBeDefined();
+    expect(token.type).toBe("refresh");
+    expect(token.tokenHash).toBe(tokenData.tokenHash);
+    expect(token.clientId).toBe(testClientId);
+    expect(token.userId).toBe(testUserId);
+    expect(token.scope).toBe("read");
+    expect(token.jwtId).toBe("new-test-jwt-id");
+    expect(token.isActive).toBe(true);
+
+    // Clean up the created token
+    await db.delete(tokens).where(eq(tokens.id, token.id));
+  });
+
+  test("should get a token by ID", async () => {
+    const token = await tokensService.getTokenById(testTokenId);
+
+    expect(token).toBeDefined();
+    expect(token?.id).toBe(testTokenId);
+    expect(token?.type).toBe("access");
+    expect(token?.tokenHash).toBe(testTokenHash);
+    expect(token?.clientId).toBe(testClientId);
+    expect(token?.userId).toBe(testUserId);
+    expect(token?.scope).toBe("read write");
+    expect(token?.jwtId).toBe("test-jwt-id");
+    expect(token?.isActive).toBe(true);
+  });
+
+  test("should verify a token by hash", async () => {
+    const token = await tokensService.verifyToken(testTokenHash);
+
+    expect(token).toBeDefined();
+    expect(token?.id).toBe(testTokenId);
+    expect(token?.type).toBe("access");
+    expect(token?.tokenHash).toBe(testTokenHash);
+    expect(token?.clientId).toBe(testClientId);
+    expect(token?.userId).toBe(testUserId);
+    expect(token?.scope).toBe("read write");
+    expect(token?.jwtId).toBe("test-jwt-id");
+    expect(token?.isActive).toBe(true);
+  });
+
+  test("should revoke a token", async () => {
+    await tokensService.revokeToken(testTokenId, "Test revocation");
+
+    const token = await tokensService.getTokenById(testTokenId);
+    expect(token).toBeDefined();
+    expect(token?.isActive).toBe(false);
+    expect(token?.revokedAt).toBeDefined();
+    expect(token?.revocationReason).toBe("Test revocation");
+
+    // Verify that the token can no longer be verified
+    const verifiedToken = await tokensService.verifyToken(testTokenHash);
+    expect(verifiedToken).toBeNull();
+  });
+
+  test("should get token status", async () => {
+    // First check an active token
+    let status = await tokensService.getTokenStatus(testTokenId);
+    expect(status).toBe(TokenStatus.ACTIVE);
+
+    // Now revoke the token and check again
+    await tokensService.revokeToken(testTokenId, "Test revocation");
+    status = await tokensService.getTokenStatus(testTokenId);
+    expect(status).toBe(TokenStatus.REVOKED);
+  });
+
+  test("should list active tokens for a user", async () => {
+    // Create a second token for the same user
+    await tokensService.createToken({
+      type: "refresh",
+      tokenHash: tokensService.hashToken("second-test-token"),
+      clientId: testClientId,
+      userId: testUserId,
+      scope: "read",
+      jwtId: "second-test-jwt-id",
+      expiresAt: new Date(Date.now() + 86400000), // 24 hours from now
+    });
+
+    const tokens = await tokensService.listActiveTokens(testUserId);
+
+    expect(tokens).toBeDefined();
+    expect(tokens.length).toBeGreaterThanOrEqual(2);
+
+    // Filter to only our test tokens
+    const testTokens = tokens.filter((t) => t.clientId === testClientId);
+    expect(testTokens.length).toBeGreaterThanOrEqual(2);
+
+    // Check filtering by client ID
+    const clientTokens = await tokensService.listActiveTokens(
+      testUserId,
+      testClientId,
+    );
+    expect(clientTokens.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("should clean up expired tokens", async () => {
+    // Create an expired token
+    await db.insert(tokens).values({
+      type: "access",
+      tokenHash: tokensService.hashToken("expired-test-token"),
+      clientId: testClientId,
+      userId: testUserId,
+      scope: "read",
+      jwtId: "expired-test-jwt-id",
+      expiresAt: new Date(Date.now() - 3600000), // 1 hour in the past
+      isActive: true,
+    });
+
+    // Create a revoked token
+    await db
+      .insert(tokens)
+      .values({
+        type: "access",
+        tokenHash: tokensService.hashToken("revoked-test-token"),
+        clientId: testClientId,
+        userId: testUserId,
+        scope: "read",
+        jwtId: "revoked-test-jwt-id",
+        expiresAt: new Date(Date.now() + 3600000), // 1 hour from now
+        isActive: false,
+        revokedAt: new Date(),
+        revocationReason: "Test revocation",
+      })
+      .returning();
+
+    // Run cleanup
+    const count = await tokensService.cleanupExpiredTokens();
+
+    // Should have removed at least the expired token
+    expect(count).toBeGreaterThanOrEqual(1);
+
+    // Verify the expired token is gone
+    const expiredToken = await db
+      .select()
+      .from(tokens)
+      .where(
+        eq(tokens.tokenHash, tokensService.hashToken("expired-test-token")),
+      );
+    expect(expiredToken.length).toBe(0);
+  });
+
+  test("should hash a token", () => {
+    const hash = tokensService.hashToken("test-token");
+
+    expect(hash).toBeDefined();
+    expect(typeof hash).toBe("string");
+    expect(hash.length).toBe(64); // SHA-256 hash is 64 characters in hex
+
+    // Verify the hash is consistent
+    const hash2 = tokensService.hashToken("test-token");
+    expect(hash).toBe(hash2);
+
+    // Verify different tokens produce different hashes
+    const hash3 = tokensService.hashToken("different-token");
+    expect(hash).not.toBe(hash3);
+  });
+});


### PR DESCRIPTION
- Implements core token management functionality in `TokensService`:
  - `createToken`, `getTokenById`, `verifyToken`, `revokeToken`
  - `getTokenStatus`, `listActiveTokens`, `cleanupExpiredTokens`
  - `hashToken`
- Adds comprehensive integration tests for `TokensService`, `CredentialsService`, and `KeysService`.
- Fixes Swagger UI endpoint configuration (`/docs`) to correctly load the API definition.
- Resolves foreign key violation in `AuthorizationService` integration test cleanup by deleting dependent roles/permissions first.
- Refactors `AuthorizationService` test imports to use TypeScript path aliases. 